### PR TITLE
fix(core:paths): path management

### DIFF
--- a/cli/cmds/cmd-paths.ts
+++ b/cli/cmds/cmd-paths.ts
@@ -8,6 +8,7 @@ import { Argv, CommandModule } from 'yargs'
 import { ServersManager } from '../../core/components/handlers/servers'
 import { PathsManager } from '../../core/components/handlers/paths'
 import { CONFLICT_MODE, DIFF_MODE, SYNC_MODE } from '../../core/components/constants/diff'
+import { SYNC_PATH_REPOSITORY } from '@sync-in-desktop/core/components/constants/paths'
 
 const pathLS: CommandModule = {
   command: 'list',
@@ -43,7 +44,7 @@ const pathADD: CommandModule = {
     },
     remotePath: {
       alias: 'r',
-      describe: 'Path to a folder or a file on your server, path must start with "spaces" | "personal" | "shares" to identify the location',
+      describe: `Path to a folder or a file on your server, path must start with "${SYNC_PATH_REPOSITORY.PERSONAL}" | "${SYNC_PATH_REPOSITORY.SPACES}" | "${SYNC_PATH_REPOSITORY.SHARES}" to identify the location`,
       type: 'string',
       demandOption: true
     },

--- a/core/components/constants/paths.ts
+++ b/core/components/constants/paths.ts
@@ -4,6 +4,12 @@
  * See the LICENSE file for licensing details
  */
 
+export enum SYNC_PATH_REPOSITORY {
+  PERSONAL = 'personal',
+  SPACES = 'spaces',
+  SHARES = 'shares'
+}
+
 export enum SYNC_PATH_PERMISSION {
   ADD = 'a',
   MODIFY = 'm',

--- a/core/components/models/syncpath.ts
+++ b/core/components/models/syncpath.ts
@@ -10,7 +10,7 @@ import path from 'node:path'
 import { SNAPSHOTS_PATH, SYNC_LOGS_PATH } from '../../constants'
 import fs from 'node:fs/promises'
 import { SyncPathSettings } from '../interfaces/sync-path-settings.interface'
-import { SYNC_PATH_PERMISSION } from '../constants/permissions'
+import { SYNC_PATH_PERMISSION } from '../constants/paths'
 import type { SyncTransfer } from '../interfaces/sync-transfer.interface'
 import { CONFLICT_MODE, DIFF_MODE, SYNC_MODE } from '../constants/diff'
 

--- a/core/main.ts
+++ b/core/main.ts
@@ -142,7 +142,7 @@ export class RunManager {
 
   private getPaths(server: Server, filterPaths?: (number | string)[]): SyncPath[] {
     if (filterPaths) {
-      const syncPaths: SyncPath[] = filterPaths.map((sp) => findByNameOrID(sp, server.syncPaths))
+      const syncPaths: SyncPath[] = filterPaths.map((sp) => findByNameOrID(sp, server.syncPaths)).filter(Boolean)
       if (syncPaths.length) {
         return syncPaths.filter((sp) => sp.enabled)
       } else {


### PR DESCRIPTION
- Fixes #22
- Enforce subdirectory rules for repositories
- Normalize localPath and remotePath handling
- Filter out invalid sync paths in getPaths